### PR TITLE
fix: Correct homebrew command to use bash instead of ruby

### DIFF
--- a/mac-setup.sh
+++ b/mac-setup.sh
@@ -4,7 +4,7 @@
 if test ! $(which brew)
 then
   echo "  Installing Homebrew for you."
-  /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)" > /tmp/homebrew-install.log
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
 # Install my brew packages


### PR DESCRIPTION
Closes #2 .

Updated the command to install homebrew in the mac setup script.