### PR TITLE
refactor: Rename osx plugin to macos

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -76,7 +76,7 @@ plugins=(
 	yarn
 	npm
 	bgnotify
-	osx
+	macos
 )
 
 source $ZSH/oh-my-zsh.sh


### PR DESCRIPTION
zsh was complaining that the osx plugin was renamed to macos.﻿
